### PR TITLE
Fix HIP lib path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ AC_ARG_WITH([libfabric],
 AC_DEFINE([__HIP_PLATFORM_HCC__], [], [Use HCC Platform])
 AC_ARG_WITH([hip],
             AC_HELP_STRING([--with-hip=PATH], [Path to non-standard HIP installation]),
-            [AS_IF([test -d $withval/lib64], [hip_libdir="lib64"], [hip_libdir="lib"])
+            [AS_IF([test -d $withval/lib], [hip_libdir="lib"], [hip_libdir="lib64"])
              CFLAGS="-I$withval/include $CFLAGS"
              LDFLAGS="-L$withval/$hip_libdir $LDFLAGS"],
             [CFLAGS="-I/opt/rocm/include $CFLAGS"


### PR DESCRIPTION
*Issue #, if available:* 
Configure step was looking for libamdhip64.so in given ROCM_PATH/lib64 instead of ROCM_PATH/lib where it is usually found in ROCm releases

*Description of changes:*
Fix the order of paths to look for in configure.ac.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
